### PR TITLE
added basic area scaling for confusion matrix cells

### DIFF
--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -195,7 +195,13 @@ export class ConfusionMatrix implements IAppView {
       .append('div')
       .classed('cell', true);
 
+    const maxVal = Math.max(...data1D);
+
     $cells
+      .style('align-self', 'center')
+      .style('justify-self', 'center')
+      .style('height', (datum: any) => String(10 + datum / maxVal * 80) + '%')
+      .style('width', (datum: any) => String(10 + datum / maxVal * 80) + '%')
       .text((datum: any) => datum)
       .style('background-color', (datum: number) => heatmapColorScale(datum))
       .style('color', (datum: number) => adaptTextColorToBgColor(heatmapColorScale(datum).toString()));


### PR DESCRIPTION
Closes #26.

we still need a way to specify the scaling factor of the cells.
currently it's simply scaled between 10 and 90 percent of the height and width of the cells.




