### PR TITLE
Nmo13/features/normalize barchart height

### DIFF
--- a/src/BarChart.ts
+++ b/src/BarChart.ts
@@ -19,12 +19,12 @@ export class BarChart {
   }
 
 
-  render(bins: IClassAffiliation[]) {
+  render(bins: IClassAffiliation[], minValue: number, maxValue: number) {
     const $g = this.$node;
 
     const x = d3.scale.ordinal().domain(bins.map((x) => x.label)).rangeRoundBands([0, this.width]);
     const y = d3.scale.linear().rangeRound([this.height, 0]);
-    y.domain([0, d3.max(bins, (d) => { return d.count; })]);
+    y.domain([minValue, maxValue]);
 
     const $bars = $g.selectAll('.bar')
     .data(bins);

--- a/src/CellRenderer.ts
+++ b/src/CellRenderer.ts
@@ -20,16 +20,14 @@ export abstract class ACellRenderer {
 }
 
 export class SingleLineChartCellRenderer extends ACellRenderer {
-  maxVal: number;
-  minVal: number;
 
   constructor(private data: Matrix<IClassEvolution>, private filterZeroLines, private singleEpochIndex: number, protected $parent: d3.Selection<any>) {
     super();
-    this.maxVal = max(data, (d) => Math.max(...d.values));
-    this.minVal = min(data, (d) => Math.min(...d.values));
   }
 
   renderCells() {
+    const maxVal = max(this.data, (d) => Math.max(...d.values));
+    const minVal = min(this.data, (d) => Math.min(...d.values));
     const r = this.data.to1DArray();
 
     this.$parent.selectAll('div').remove();
@@ -44,7 +42,7 @@ export class SingleLineChartCellRenderer extends ACellRenderer {
       if(that.filterZeroLines && !d.values.find((val) => val !== 0)) {
         return;
       }
-      new LineChart(d3.select(this)).render(d, that.maxVal, that.minVal, that.singleEpochIndex);
+      new LineChart(d3.select(this)).render(d, maxVal, minVal, that.singleEpochIndex);
     });
   }
 
@@ -86,6 +84,10 @@ export class BarChartCellRenderer extends ACellRenderer {
   }
 
   renderCells() {
+
+    const maxVal = max(this.data, (d) => d.count);
+    const minVal = 0;
+
     const $cells = this.$parent
       .selectAll('div')
       .data(this.data.values, (d) => this.createKey(d));
@@ -102,7 +104,7 @@ export class BarChartCellRenderer extends ACellRenderer {
     this.attachListener($enterSelection);
 
     $enterSelection.each(function(d, i) {
-        new BarChart(d3.select(this), {top:0, bottom:0, left:0, right:0}).render(d);
+        new BarChart(d3.select(this), {top:0, bottom:0, left:0, right:0}).render(d, minVal, maxVal);
       });
   }
 

--- a/src/CellRenderer.ts
+++ b/src/CellRenderer.ts
@@ -86,7 +86,7 @@ export class BarChartCellRenderer extends ACellRenderer {
   renderCells() {
 
     const maxVal = max(this.data, (d) => d.count);
-    const minVal = 0;
+    const minVal = min(this.data, (d) => d.count);
 
     const $cells = this.$parent
       .selectAll('div')

--- a/src/CellRenderer.ts
+++ b/src/CellRenderer.ts
@@ -27,7 +27,7 @@ export class SingleLineChartCellRenderer extends ACellRenderer {
 
   renderCells() {
     const maxVal = max(this.data, (d) => Math.max(...d.values));
-    const minVal = min(this.data, (d) => Math.min(...d.values));
+    const minVal = 0;
     const r = this.data.to1DArray();
 
     this.$parent.selectAll('div').remove();
@@ -59,7 +59,7 @@ export class MultilineChartCellRenderer extends ACellRenderer {
 
   renderCells() {
     const maxVal = max(this.data, (d) => Math.max(...d.values));
-    const minVal = min(this.data, (d) => Math.min(...d.values));
+    const minVal = 0;
     this.$parent.selectAll('div').remove();
     const $cells = this.$parent.selectAll('div').data(this.data.values);
     $cells.enter().append('div')
@@ -86,7 +86,7 @@ export class BarChartCellRenderer extends ACellRenderer {
   renderCells() {
 
     const maxVal = max(this.data, (d) => d.count);
-    const minVal = min(this.data, (d) => d.count);
+    const minVal = 0;
 
     const $cells = this.$parent
       .selectAll('div')
@@ -211,7 +211,7 @@ export class MultiEpochCellRenderer extends ACellRenderer {
     console.assert(hmData1D.length === lineData1D.length);
 
     const maxVal = max(this.lineData, (d) => Math.max(...d.values));
-    const minVal = min(this.lineData, (d) => Math.min(...d.values));
+    const minVal = 0;
 
     const transformedData:ICombinedType[] = hmData1D.map((d, i):ICombinedType => {
       return {'linedata': lineData1D[i], 'hmdata': hmData1D[i]};


### PR DESCRIPTION
Closes https://github.com/Caleydo/malevo/issues/39

The max value for all barcharts is now set to the greatest value in the data.
The min value for all barcharts is  set to the smallest value in the data. However, this value is always 0 since the confusion matrix diagonal is always 0.

![image](https://user-images.githubusercontent.com/3988444/36416925-c89ab350-162a-11e8-8f2e-7bf55b935f9f.png)
