### PR TITLE
Update overall layout and design changes

### DIFF
--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -380,7 +380,7 @@ export class ConfusionMatrix implements IAppView {
         functors: [this.setWeightUpdateListener]
       };
       precRendererProto = {
-        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params: [-1, -1]}], offdiagonal: null,
+        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}], offdiagonal: null,
         functors: []
       };
     }

--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -297,7 +297,7 @@ export class ConfusionMatrix implements IAppView {
     this.$confusionMatrix.selectAll('div.cell').each((d: ACell) => removeListeners(d.renderer, [(r: ACellRenderer) => r.removeWeightFactorChangedListener()]));
     this.fpColumn.$node.selectAll('div.cell').each((d: ACell) => removeListeners(d.renderer, [(r: ACellRenderer) => r.removeWeightFactorChangedListener()]));
     this.fnColumn.$node.selectAll('div.cell').each((d: ACell) => removeListeners(d.renderer, [(r: ACellRenderer) => r.removeWeightFactorChangedListener()]));
-    events.off(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, null);
+    events.off(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, null);
   }
 
   renderCells(datasets: ILoadedMalevoDataset[]) {
@@ -333,13 +333,19 @@ export class ConfusionMatrix implements IAppView {
       dataPrecision = datasets.map((x) => confMeasures.calcEvolution(x.multiEpochData.map((y) => y.confusionData), confMeasures.PPV));
       singleEpochIndex = data[1].heatcell.indexInMultiSelection;
 
-      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params:[DataStoreApplicationProperties.transposeCellRenderer]},
-        {renderer: 'SingleEpochMarker', params:[DataStoreApplicationProperties.transposeCellRenderer]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]};
+      confMatrixRendererProto = {
+        offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params: [DataStoreApplicationProperties.transposeCellRenderer]},
+        {renderer: 'SingleEpochMarker', params: [DataStoreApplicationProperties.transposeCellRenderer]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]
+      };
 
-      fpfnRendererProto = {diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params:[-1, -1]}], offdiagonal: null,
-        functors: [this.setWeightUpdateListener]};
-      precRendererProto = {diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params:[-1, -1]}], offdiagonal: null,
-        functors: []};
+      fpfnRendererProto = {
+        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params: [-1, -1]}], offdiagonal: null,
+        functors: [this.setWeightUpdateListener]
+      };
+      precRendererProto = {
+        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params: [-1, -1]}], offdiagonal: null,
+        functors: []
+      };
 
     } else if (DataStoreApplicationProperties.renderMode === RenderMode.SINGLE) {
       singleEpochContent = new SingleEpochCalculator().calculate(datasets);
@@ -359,8 +365,10 @@ export class ConfusionMatrix implements IAppView {
       dataPrecision = datasets.map((x) => confMeasures.calcEvolution(x.multiEpochData.map((y) => y.confusionData), confMeasures.PPV));
       singleEpochIndex = null;
 
-      confMatrixRendererProto = {offdiagonal: [new HeatmapMultiEpochRenderer(DataStoreApplicationProperties.transposeCellRenderer)],
-        diagonal: [new LabelCellRenderer()], functors: [this.setWeightUpdateListener]};
+      confMatrixRendererProto = {
+        offdiagonal: [new HeatmapMultiEpochRenderer(DataStoreApplicationProperties.transposeCellRenderer)],
+        diagonal: [new LabelCellRenderer()], functors: [this.setWeightUpdateListener]
+      };
       fpfnRendererProto = {offdiagonal: null, diagonal: [new MatrixLineCellRenderer()], functors: [this.setWeightUpdateListener]};
       precRendererProto = {offdiagonal: null, diagonal: [new MatrixLineCellRenderer(), new VerticalLineRenderer(-1, -1)], functors: []};
     }

--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -140,7 +140,7 @@ export class ConfusionMatrix implements IAppView {
     });
 
     events.on(AppConstants.EVENT_CELL_RENDERER_CHANGED, (evt, switched) => {
-      if(this.$cells == null) {
+      if (this.$cells == null) {
         return;
       }
       this.$cells.each((c) => {
@@ -297,7 +297,10 @@ export class ConfusionMatrix implements IAppView {
   }
 
   private detachListeners() {
-    const remove = (element: d3.Selection<any>) => {element.selectAll('div.cell').each((d: ACell) => removeListeners(d.renderer, [(r: ACellRenderer) => r.removeWeightFactorChangedListener()]))}
+    const remove = (element: d3.Selection<any>) => {
+      return element.selectAll('div.cell')
+        .each((d: ACell) => removeListeners(d.renderer, [(r: ACellRenderer) => r.removeWeightFactorChangedListener()]));
+    };
     remove(this.$confusionMatrix);
     remove(this.fpColumn.$node);
     remove(this.fnColumn.$node);
@@ -355,11 +358,15 @@ export class ConfusionMatrix implements IAppView {
       dataPrecision = datasets.map((x) => confMeasures.calcEvolution([x.singleEpochData.confusionData], confMeasures.PPV));
       singleEpochIndex = data[0].heatcell.indexInMultiSelection;
 
-      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapSingleEpochRenderer', params:[false, false]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]};
-      fpfnRendererProto = {diagonal: [{renderer: 'BarChartRenderer', params: null}], offdiagonal: null,
-        functors: [this.setWeightUpdateListener]};
-      precRendererProto = {diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params:[-1, -1]}], offdiagonal: null,
-        functors: []};
+      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapSingleEpochRenderer', params: [false, false]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]};
+      fpfnRendererProto = {
+        diagonal: [{renderer: 'BarChartRenderer', params: null}], offdiagonal: null,
+        functors: [this.setWeightUpdateListener]
+      };
+      precRendererProto = {
+        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params: [-1, -1]}], offdiagonal: null,
+        functors: []
+      };
 
     } else if (DataStoreApplicationProperties.renderMode === RenderMode.MULTI) {
       multiEpochContent = new MultiEpochCalculator().calculate(datasets);
@@ -368,11 +375,15 @@ export class ConfusionMatrix implements IAppView {
       dataPrecision = datasets.map((x) => confMeasures.calcEvolution(x.multiEpochData.map((y) => y.confusionData), confMeasures.PPV));
       singleEpochIndex = null;
 
-      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params:[DataStoreApplicationProperties.transposeCellRenderer]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]};
-      fpfnRendererProto = {diagonal: [{renderer: 'BarChartRenderer', params: null}], offdiagonal: null,
-        functors: [this.setWeightUpdateListener]};
-      precRendererProto = {diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params:[-1, -1]}], offdiagonal: null,
-        functors: []};
+      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params: [DataStoreApplicationProperties.transposeCellRenderer]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]};
+      fpfnRendererProto = {
+        diagonal: [{renderer: 'BarChartRenderer', params: null}], offdiagonal: null,
+        functors: [this.setWeightUpdateListener]
+      };
+      precRendererProto = {
+        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}, {renderer: 'VerticalLineRenderer', params: [-1, -1]}], offdiagonal: null,
+        functors: []
+      };
     }
 
     const that = this;

--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -376,7 +376,7 @@ export class ConfusionMatrix implements IAppView {
 
       confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params: [DataStoreApplicationProperties.transposeCellRenderer]}], diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener]};
       fpfnRendererProto = {
-        diagonal: [{renderer: 'BarChartRenderer', params: null}], offdiagonal: null,
+        diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}], offdiagonal: null,
         functors: [this.setWeightUpdateListener]
       };
       precRendererProto = {

--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -101,7 +101,7 @@ export class ConfusionMatrix implements IAppView {
     this.$node.append('div')
       .classed('malevo-label', true)
       .classed('label-bottom', true)
-      .text(Language.FP);
+      .html(`<span>${Language.FP}</span>`);
 
     this.$labelsTop = this.$node.append('div')
       .classed('malevo-label', true)
@@ -317,7 +317,7 @@ export class ConfusionMatrix implements IAppView {
       .classed('label-cell', true);
 
     $cells
-      .text((datum: string) => datum);
+      .html((datum: string) => `<span>${datum}</span>`);
 
     $cells.exit().remove();
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -88,8 +88,8 @@ export class App implements IAppView {
   constructor(parent: Element) {
     this.$node = d3.select(parent);
 
-    this.$node.append('div').classed('timeline-wrapper', true);
     const $main = this.$node.append('main').classed('main-wrapper', true);
+    $main.append('div').classed('timeline-wrapper', true);
     $main.append('div').classed('toolbar-wrapper', true);
     $main.append('div').classed('conf-matrix-wrapper', true);
     $main.append('div').classed('details-wrapper', true);

--- a/src/confusion_matrix_cell/ACellRenderer.ts
+++ b/src/confusion_matrix_cell/ACellRenderer.ts
@@ -241,30 +241,24 @@ export class HeatmapMultiEpochRenderer extends ACellRenderer implements ITranspo
   protected render(cell: MatrixCell | PanelCell) {
     this.cell = cell;
     const data: Line[] = [].concat.apply([], cell.data.linecell);
-    const gradientDirection = (this.isTransposed) ? 'to bottom' : 'to right';
 
     const $subCells = cell.$node
       .selectAll('div')
       .data(data);
 
     $subCells.enter().append('div').classed('heat-cell', true);
-    $subCells.style('background', (datum: Line) => {
-      const colorScale = d3.scale.linear().domain([0, datum.max]).range(<any>['white', datum.color]);
-      const widthInPercent = 100 / datum.values.length;
-      let res = datum.values.reduce((acc, val, index) => {
-        return acc + colorScale(val) + ' ' + (index) * widthInPercent + '%, ' + colorScale(val) + ' ' + (index + 1) * widthInPercent + '%, ';
-      }, '');
-      res = res.substring(0, res.length - 2);
-      return `linear-gradient(${gradientDirection}, ${res})`;
-    });
+    this.update();
+  }
+
+  private getColorScale(datum: Line) {
+    return d3.scale.pow().exponent(DataStoreApplicationProperties.weightFactor).domain([0, datum.max]).range(<any>['white', datum.color]);
   }
 
   private update = () => {
     const gradientDirection = (this.isTransposed) ? 'to bottom' : 'to right';
-    const data: Line[] = [].concat.apply([], this.cell.data.linecell);
     const $subCells = this.cell.$node.selectAll('.heat-cell');
     $subCells.style('background', (datum: Line) => {
-      const colorScale = d3.scale.pow().exponent(DataStoreApplicationProperties.weightFactor).domain([0, datum.max]).range(<any>['white', datum.color]);
+      const colorScale = this.getColorScale(datum);
       const widthInPercent = 100 / datum.values.length;
       let res = datum.values.reduce((acc, val, index) => {
         return acc + colorScale(val) + ' ' + (index) * widthInPercent + '%, ' + colorScale(val) + ' ' + (index + 1) * widthInPercent + '%, ';

--- a/src/confusion_matrix_cell/ACellRenderer.ts
+++ b/src/confusion_matrix_cell/ACellRenderer.ts
@@ -26,7 +26,7 @@ export interface IRendererConfig {
 export interface IMatrixRendererChain {
   offdiagonal: IRendererConfig[];
   diagonal: IRendererConfig[];
-  functors: { (renderer: ACellRenderer): void; } [];
+  functors: {(renderer: ACellRenderer): void;}[];
 }
 
 export abstract class ACellRenderer {
@@ -50,8 +50,8 @@ export class LineChartRenderer extends ACellRenderer {
   protected cell: MatrixCell | PanelCell;
 
   private update = () => {
-      const data: Line[] = [].concat.apply([], this.cell.data.linecell);
-      this.renderLine(data, this.cell.$node);
+    const data: Line[] = [].concat.apply([], this.cell.data.linecell);
+    this.renderLine(data, this.cell.$node);
   }
 
   constructor(protected width: number, protected height: number) {
@@ -83,11 +83,11 @@ export class LineChartRenderer extends ACellRenderer {
   }
 
   public addWeightFactorChangedListener() {
-    events.on(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, this.update);
+    events.on(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, this.update);
   }
 
   public removeWeightFactorChangedListener() {
-    events.off(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, this.update);
+    events.off(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, this.update);
   }
 
   protected render(cell: MatrixCell | PanelCell) {
@@ -264,7 +264,7 @@ export class HeatmapMultiEpochRenderer extends ACellRenderer implements ITranspo
     const data: Line[] = [].concat.apply([], this.cell.data.linecell);
     const $subCells = this.cell.$node.selectAll('.heat-cell');
     $subCells.style('background', (datum: Line) => {
-      const colorScale = d3.scale.pow().exponent(DataStoreApplicationProperties.weightfactor).domain([0, datum.max]).range(<any>['white', datum.color]);
+      const colorScale = d3.scale.pow().exponent(DataStoreApplicationProperties.weightFactor).domain([0, datum.max]).range(<any>['white', datum.color]);
       const widthInPercent = 100 / datum.values.length;
       let res = datum.values.reduce((acc, val, index) => {
         return acc + colorScale(val) + ' ' + (index) * widthInPercent + '%, ' + colorScale(val) + ' ' + (index + 1) * widthInPercent + '%, ';
@@ -275,11 +275,11 @@ export class HeatmapMultiEpochRenderer extends ACellRenderer implements ITranspo
   }
 
   public addWeightFactorChangedListener() {
-    events.on(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, this.update);
+    events.on(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, this.update);
   }
 
   public removeWeightFactorChangedListener() {
-    events.off(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, this.update);
+    events.off(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, this.update);
   }
 }
 
@@ -320,8 +320,8 @@ export class AxisRenderer extends ACellRenderer {
   private $g: d3.Selection<any> = null;
 
   private update = () => {
-    if(this.$g !== null) {
-        this.updateYAxis(DataStoreApplicationProperties.weightfactor);
+    if (this.$g !== null) {
+      this.updateYAxis(DataStoreApplicationProperties.weightFactor);
     }
   }
 
@@ -333,15 +333,15 @@ export class AxisRenderer extends ACellRenderer {
   }
 
   public addWeightFactorChangedListener() {
-    events.on(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, this.update);
+    events.on(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, this.update);
   }
 
   public removeWeightFactorChangedListener() {
-    events.off(AppConstants.EVENT_WEIGHTFACTOR_CHANGED, this.update);
+    events.off(AppConstants.EVENT_WEIGHT_FACTOR_CHANGED, this.update);
   }
 
   private updateYAxis(value: number) {
-    this.y.exponent(value).domain([0,getLargestLine(this.data).max]).range([this.height,0]);
+    this.y.exponent(value).domain([0, getLargestLine(this.data).max]).range([this.height, 0]);
     this.yAxis.scale(this.y);
     this.$g.select('.chart-axis-y').call(this.yAxis);
   }
@@ -426,28 +426,28 @@ function getLargestLine(data: Line[]): Line {
 }
 
 export function applyRendererChain2(rendererProto: IMatrixRendererChain, cell: ACell, target: IRendererConfig[]) {
-    let firstRenderer = null;
-    target.reduce((acc: ACellRenderer, val: IRendererConfig) => {
+  let firstRenderer = null;
+  target.reduce((acc: ACellRenderer, val: IRendererConfig) => {
     const copy = rendererFactory(val);
     rendererProto.functors.forEach((f) => f(copy));
-    if(acc === null) {
+    if (acc === null) {
       firstRenderer = copy;
       return copy;
     }
     acc.setNextRenderer(copy);
     return copy;
-    }, null);
-    cell.renderer = firstRenderer;
+  }, null);
+  cell.renderer = firstRenderer;
 }
 
 function rendererFactory(proto: IRendererConfig) {
-  switch(proto.renderer) {
+  switch (proto.renderer) {
     case 'HeatmapMultiEpochRenderer':
       return new HeatmapMultiEpochRenderer(proto.params[0]);
     case 'SingleEpochMarker':
       return new SingleEpochMarker(proto.params[0]);
     case 'LinechartRenderer':
-      return new LinechartRenderer(proto.params[0], proto.params[1]);
+      return new LineChartRenderer(proto.params[0], proto.params[1]);
     case 'AxisRenderer':
       return new AxisRenderer(proto.params[0], proto.params[1]);
     case 'VerticalLineRenderer':
@@ -470,7 +470,7 @@ export function createCellRenderers($cells: d3.Selection<any>, renderProto: IMat
 
 export function removeListeners(renderChain: ACellRenderer, funct: ((r: ACellRenderer) => any)[]) {
   let curRenderer = renderChain;
-  while(curRenderer !== null) {
+  while (curRenderer !== null) {
     funct.forEach((f) => f(curRenderer));
     curRenderer = curRenderer.nextRenderer;
   }

--- a/src/confusion_matrix_cell/ACellRenderer.ts
+++ b/src/confusion_matrix_cell/ACellRenderer.ts
@@ -296,7 +296,6 @@ export class AxisRenderer extends ACellRenderer {
   }
 
   private updateYAxis(value: number) {
-    console.log(value);
     this.y.exponent(value).domain([0, getLargestLine(this.data).max]).range([this.height, 0]);
     this.yAxis.scale(this.y);
     this.$g.select('.chart-axis-y').call(this.yAxis);

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -18,22 +18,13 @@ b,
   font-weight: 500 !important;
 }
 
-.timeline-wrapper {
-  width: 100%;
-  margin: 5px 0;
-  display: flex;
-  align-items: flex-start;
-  overflow-x: auto;
-  padding: 5px 0;
-}
-
 .main-wrapper {
   display: grid;
-  grid-template-areas: "toolbar matrix details";
+  grid-template-areas: "toolbar matrix timeline" "toolbar matrix details";
   grid-template-columns: 40px minmax(auto, 98vh) minmax(40%, auto);
-  grid-template-rows: minmax(min-content, 85vh);
+  grid-template-rows: minmax(35px, max-content) minmax(min-content, 80vh);
   grid-gap: 20px;
-  margin: 0 10px;
+  margin: 10px;
 }
 
 .conf-matrix-wrapper {

--- a/src/styles/_confusionmatrix.scss
+++ b/src/styles/_confusionmatrix.scss
@@ -5,11 +5,20 @@
 // number of columns placed to the right of the confusion matrix
 $num-columns-right-area: 3;
 
+@mixin rotateSpanLabel() {
+  > span {
+    display: block;
+    transform: rotate(-180deg);
+    writing-mode: vertical-lr;
+    white-space: nowrap;
+  }
+}
+
 .grid {
   display: grid;
   grid-template-areas: ". . axis-top ." ". . label-top label-right" "axis-left label-left matrix chart-right" ". label-bottom chart-bottom .";
-  grid-template-columns: 20px 70px auto minmax(100px, 200px);
-  grid-template-rows: 20px 50px auto minmax(60px, 1fr);
+  grid-template-columns: 20px 45px auto minmax(100px, 200px);
+  grid-template-rows: 20px 45px auto minmax(60px, 1fr);
 }
 
 .malevo-label {
@@ -35,12 +44,7 @@ $num-columns-right-area: 3;
     border-right: 1px solid lighten($label-border, 5%);
     padding-top: 10px;
 
-    > span {
-      display: block;
-      transform: rotate(-180deg);
-      writing-mode: vertical-lr;
-      white-space: nowrap;
-    }
+    @include rotateSpanLabel();
   }
 }
 
@@ -64,6 +68,8 @@ $num-columns-right-area: 3;
   display: flex;
   align-items: center;
   justify-content: center;
+
+  @include rotateSpanLabel();
 }
 
 .label-top {
@@ -78,6 +84,10 @@ $num-columns-right-area: 3;
   position: relative;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(100%, 1fr));
+
+  .label-cell {
+    @include rotateSpanLabel();
+  }
 }
 
 .chart-right {

--- a/src/styles/_confusionmatrix.scss
+++ b/src/styles/_confusionmatrix.scss
@@ -7,12 +7,11 @@ $num-columns-right-area: 3;
 
 .grid {
   display: grid;
-  grid-template-areas: ". axis-top axis-top ." ". . label-top label-right" "axis-left label-left matrix chart-right" ". label-bottom chart-bottom .";
-  grid-template-columns: 40px 50px auto minmax(100px, 200px);
-  grid-template-rows: 40px 50px auto minmax(60px, 1fr);
+  grid-template-areas: ". . axis-top ." ". . label-top label-right" "axis-left label-left matrix chart-right" ". label-bottom chart-bottom .";
+  grid-template-columns: 20px 70px auto minmax(100px, 200px);
+  grid-template-rows: 20px 50px auto minmax(60px, 1fr);
 }
 
-.cfm-axis,
 .malevo-label {
   font-weight: 500;
   font-size: 16px;
@@ -21,15 +20,20 @@ $num-columns-right-area: 3;
 .cfm-axis {
   background: $label-bg;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-start;
+  justify-content: flex-start;
+  color: darken($label-border, 2%);
 
   &.axis-top {
     grid-area: axis-top;
+    border-bottom: 1px solid lighten($label-border, 5%);
+    padding-left: 10px;
   }
 
   &.axis-left {
     grid-area: axis-left;
+    border-right: 1px solid lighten($label-border, 5%);
+    padding-top: 10px;
 
     > span {
       display: block;

--- a/src/styles/_confusionmatrix.scss
+++ b/src/styles/_confusionmatrix.scss
@@ -31,7 +31,7 @@ $num-columns-right-area: 3;
   display: flex;
   align-items: flex-start;
   justify-content: flex-start;
-  color: darken($label-border, 2%);
+  color: darken($label-border, 10%);
 
   &.axis-top {
     grid-area: axis-top;

--- a/src/styles/_confusionmatrix.scss
+++ b/src/styles/_confusionmatrix.scss
@@ -16,9 +16,9 @@ $num-columns-right-area: 3;
 
 .grid {
   display: grid;
-  grid-template-areas: ". . axis-top ." ". . label-top label-right" "axis-left label-left matrix chart-right" ". label-bottom chart-bottom .";
-  grid-template-columns: 20px 45px auto minmax(100px, 200px);
-  grid-template-rows: 20px 45px auto minmax(60px, 1fr);
+  grid-template-areas: ". . axis-top . ." ". . label-top . label-right" "axis-left label-left matrix . chart-right" ". . . . ." ". label-bottom chart-bottom . .";
+  grid-template-columns: 20px 45px auto 10px minmax(100px, 240px);
+  grid-template-rows: 20px 45px auto 10px minmax(60px, 1fr);
 }
 
 .malevo-label {

--- a/src/styles/_detailview.scss
+++ b/src/styles/_detailview.scss
@@ -1,58 +1,61 @@
 @import "vars";
 .details-wrapper {
-    .selection-panel-wrapper {
-        display: flex;
-        flex-wrap: nowrap;
-        border-bottom: 1px solid $label-border;
-        >.selection-panel {
-            font-size: 16px;
-            margin: 0;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-            padding: 9px 20px;
-            margin-right: 1px;
-            text-decoration: none;
-            color: black;
-            &:active,
-            &:focus,
-            &:hover {
-                cursor: pointer;
-                background-color: $label-bg;
-            }
-            &.selected {
-                background-color: $label-border;
-                font-weight: 500;
-            }
+  .selection-panel-wrapper {
+    display: flex;
+    flex-wrap: nowrap;
+    border-bottom: 1px solid $label-border;
+
+    > .selection-panel {
+      font-size: 16px;
+      margin: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 9px 20px 4px;
+      margin-right: 1px;
+      text-decoration: none;
+      color: black;
+      border-bottom: 5px solid transparent;
+
+      &:active,
+      &:focus,
+      &:hover {
+        cursor: pointer;
+      }
+
+      &.selected {
+        border-bottom-color: $label-border;
+        font-weight: 500;
+      }
+    }
+  }
+  .view-body {
+    .viewpanel-content {
+      > svg {
+        position: relative;
+        path {
+          stroke-width: 1;
+          vector-effect: non-scaling-stroke; // prevent stroke scaling on resize
         }
+      }
+      .chart-name {
+        text-align: center;
+        font-size: 16px;
+        font-weight: 500;
+        margin-top: 10px;
+      }
     }
-    .view-body {
-        .viewpanel-content {
-            >svg {
-                position: relative;
-                path {
-                    stroke-width: 1;
-                    vector-effect: non-scaling-stroke; // prevent stroke scaling on resize
-                }
-            }
-            .chart-name {
-                text-align: center;
-                font-size: 16px;
-                font-weight: 500;
-                margin-top: 10px;
-            }
-        }
+  }
+  .chart-axis path,
+  .chart-axis line {
+    fill: none;
+    stroke: slategray;
+    shape-rendering: crispEdges;
+  }
+  .images {
+    section {
+      margin-bottom: 20px;
     }
-    .chart-axis path,
-    .chart-axis line {
-        fill: none;
-        stroke: slategray;
-        shape-rendering: crispEdges;
-    }
-    .images {
-        section {
-            margin-bottom: 20px;
-        }
-    }
+  }
 }

--- a/src/timeline/Timeline.ts
+++ b/src/timeline/Timeline.ts
@@ -71,7 +71,8 @@ export class Timeline {
   private $label: d3.Selection<any> = null;
   data: TimelineData = null;
   singleEpochSelector = null;
-  MARGIN_LEFT = 0; // 20 pixel margin from left border
+  readonly MARGIN_LEFT = 0; // 20 pixel margin from left border
+  readonly SHOW_LABEL = false;
   readonly tickmarkDistance = 5; // show ticks every 5 epoch
   readonly globalOffsetV = 15;
   private eventTimelineChangedListener = (evt: any, src: Timeline) => this.eventTimelineChanged(src);
@@ -109,6 +110,10 @@ export class Timeline {
   }
 
   createLabel(datasetName: string) {
+    if (!this.SHOW_LABEL) {
+      return;
+    }
+
     this.$label = this.$node.append('g')
       .attr('transform', 'translate(0,' + this.globalOffsetV + ')')
       .append('text')
@@ -118,7 +123,11 @@ export class Timeline {
   }
 
   getDSLabelWidth(): number {
-    return (<any>this.$label[0][0]).getBBox().width;
+    return (this.$label) ? (<any>this.$label[0][0]).getBBox().width : 0;
+  }
+
+  getWidth(): number {
+    return (<any>this.$node[0][0]).getBBox().width;
   }
 
   node(): d3.Selection<any> {
@@ -173,15 +182,18 @@ export class Timeline {
     this.createSingleSelector(width, offsetH, x);
     this.setBrush(brush, x, width);
 
-    this.$label.on('dblclick', () => {
-      // if at least 1 epoch was selected
-      if (!brush.empty()) {
-        //to clear the brush, call this.setBrush(brush, x, 0);
-        this.setBrush(brush, x, width);
-        events.fire(AppConstants.EVENT_REDRAW);
-      }
+    if (this.$label) {
+      this.$label.on('dblclick', () => {
+        // if at least 1 epoch was selected
+        if (!brush.empty()) {
+          //to clear the brush, call this.setBrush(brush, x, 0);
+          this.setBrush(brush, x, width);
+          events.fire(AppConstants.EVENT_REDRAW);
+        }
 
-    });
+      });
+
+    }
   }
 
   setBrush(brush: any, x: any, width: number) {

--- a/src/timeline/Timeline.ts
+++ b/src/timeline/Timeline.ts
@@ -36,7 +36,7 @@ class SingleEpochSelector {
 }
 
 export class OverallTimeline {
-  public dataPoints:string[] = [];
+  public dataPoints: string[] = [];
 }
 
 export class TimelineData {
@@ -52,7 +52,7 @@ export class TimelineData {
 
     epochs.sort(sortNumber);
     const length = epochs[epochs.length - 1].id;
-    for(let i = 0; i <= length; i++) {
+    for (let i = 0; i <= length; i++) {
       const epoch = epochs.find((x) => x.id === i);
       const dp = epoch ? new DataPoint(true, i, epoch) : new DataPoint(false, i, epoch);
       this.datapoints.push(dp);
@@ -69,20 +69,20 @@ class DataPoint {
 export class Timeline {
   private $node: d3.Selection<any> = null;
   private $label: d3.Selection<any> = null;
-  data:TimelineData = null;
+  data: TimelineData = null;
   singleEpochSelector = null;
-  MARGIN_LEFT = 20; // 20 pixel margin from left border
+  MARGIN_LEFT = 0; // 20 pixel margin from left border
   readonly tickmarkDistance = 5; // show ticks every 5 epoch
   readonly globalOffsetV = 15;
   private eventTimelineChangedListener = (evt: any, src: Timeline) => this.eventTimelineChanged(src);
 
   constructor(public datasetName: string, $parent: d3.Selection<any>) {
-   this.build($parent);
-   this.attachListeners();
+    this.build($parent);
+    this.attachListeners();
   }
 
   build($parent) {
-    if(this.$node) {
+    if (this.$node) {
       this.$node.remove();
     }
     this.$node = $parent.append('g')
@@ -92,7 +92,7 @@ export class Timeline {
 
   private eventTimelineChanged(src: Timeline) {
     // synchronizes single epoch marker
-    if(this.singleEpochSelector === null || src === this) {
+    if (this.singleEpochSelector === null || src === this) {
       return;
     }
     this.singleEpochSelector.setPosition(src.singleEpochSelector.curPos);
@@ -110,7 +110,7 @@ export class Timeline {
 
   createLabel(datasetName: string) {
     this.$label = this.$node.append('g')
-      .attr('transform', 'translate(0,' + this.globalOffsetV +')')
+      .attr('transform', 'translate(0,' + this.globalOffsetV + ')')
       .append('text')
       .classed('tml-label', true)
       .style('fill', dataStoreTimelines.get(this.datasetName).datasetColor)
@@ -164,7 +164,7 @@ export class Timeline {
       .style('fill', dataStoreTimelines.get(this.datasetName).datasetColor);
 
     brush.on('brush', () => this.brushmove(x, brush))
-         .on('brushend', () => that.brushAndFire(x, brush));
+      .on('brushend', () => that.brushAndFire(x, brush));
 
     const brushHeight = 15;
     $brushg.selectAll('rect')
@@ -175,7 +175,7 @@ export class Timeline {
 
     this.$label.on('dblclick', () => {
       // if at least 1 epoch was selected
-      if(!brush.empty()) {
+      if (!brush.empty()) {
         //to clear the brush, call this.setBrush(brush, x, 0);
         this.setBrush(brush, x, width);
         events.fire(AppConstants.EVENT_REDRAW);
@@ -203,14 +203,14 @@ export class Timeline {
 
       // this can happen when the timeline  is too long and has no tickmarks
       // the timeline needs to be cropped (see https://github.com/Caleydo/malevo/pull/87)
-      if(pos >= this.data.datapoints.length) {
+      if (pos >= this.data.datapoints.length) {
         pos = this.data.datapoints.length - 1;
       }
       const upperIndex = this.ceil(pos);
       const lowerIndex = this.floor(pos);
 
       console.assert(upperIndex >= pos && pos >= lowerIndex);
-      if(upperIndex - pos > pos - lowerIndex) {
+      if (upperIndex - pos > pos - lowerIndex) {
         return lowerIndex;
       } else {
         return upperIndex;
@@ -237,13 +237,13 @@ export class Timeline {
         $singleSelectionMarker.attr('x', x(pos.toString()));
       })
       .on('mouseup', function () {
-          let pos = posFromCoordinates(d3.mouse(this));
-          pos = getNearestExistPos(pos);
-          tml.singleEpochSelector.setPosition(pos);
-          // toggle single epoch selector
-          tml.updateSingleSelection();
-          events.fire(AppConstants.EVENT_TIMELINE_CHANGED, tml);
-          events.fire(AppConstants.EVENT_REDRAW);
+        let pos = posFromCoordinates(d3.mouse(this));
+        pos = getNearestExistPos(pos);
+        tml.singleEpochSelector.setPosition(pos);
+        // toggle single epoch selector
+        tml.updateSingleSelection();
+        events.fire(AppConstants.EVENT_TIMELINE_CHANGED, tml);
+        events.fire(AppConstants.EVENT_REDRAW);
       })
       .on('mouseleave', function () {
         $singleSelectionMarker.classed('hidden', true);
@@ -251,13 +251,13 @@ export class Timeline {
   }
 
   ceil(val: number) {
-    if(val < 0) {
+    if (val < 0) {
       return 0;
-    } else if(val >= this.data.datapoints.length) {
+    } else if (val >= this.data.datapoints.length) {
       return this.data.datapoints.length - 1;
     }
-    for(let i = val; i < this.data.datapoints.length; i++) {
-      if(this.data.datapoints[i].exists) {
+    for (let i = val; i < this.data.datapoints.length; i++) {
+      if (this.data.datapoints[i].exists) {
         return i;
       }
     }
@@ -265,26 +265,26 @@ export class Timeline {
   }
 
   floor(val: number) {
-    if(val < 0) {
+    if (val < 0) {
       return 0;
-    } else if(val >= this.data.datapoints.length) {
+    } else if (val >= this.data.datapoints.length) {
       return this.data.datapoints.length - 1;
     }
-    for(let i = val; i >= 0; i--) {
-      if(this.data.datapoints[i].exists) {
+    for (let i = val; i >= 0; i--) {
+      if (this.data.datapoints[i].exists) {
         return i;
       }
     }
     return null;
   }
 
-  brushmove(x: any, brush:any) {
+  brushmove(x: any, brush: any) {
     const extent = brush.extent();
     const y = d3.scale.linear().range(x.domain()).domain(x.range());
 
-    if(!brush.empty()) {
+    if (!brush.empty()) {
       const range = this.getDataIndices(+y(<number>extent[0]), +y(<number>extent[1]));
-      if(range[0] < range[1]) {
+      if (range[0] < range[1]) {
         this.$node.select('g.brush').call(<any>brush.extent([y.invert(range[0]), y.invert(range[1])]));
         this.singleEpochSelector.setPosition(range[1]);
         this.singleEpochSelector.hideNode(false);
@@ -302,7 +302,7 @@ export class Timeline {
 
   brushend(x: any, brush: any) {
     // if at least 1 epoch was selected
-    if(!brush.empty()) {
+    if (!brush.empty()) {
       const extent = brush.extent();
       const y = d3.scale.linear().range(x.domain()).domain(x.range());
       const range = this.getDataIndices(+y(<number>extent[0]), +y(<number>extent[1]));
@@ -322,8 +322,8 @@ export class Timeline {
 
   getSelectedEpochs(range: [number, number]) {
     const selEpochs = [];
-    for(let i = range[0]; i <= range[1]; i++) {
-      if(this.data.datapoints[i].exists) {
+    for (let i = range[0]; i <= range[1]; i++) {
+      if (this.data.datapoints[i].exists) {
         selEpochs.push(this.data.datapoints[i].epoch);
       }
     }
@@ -331,7 +331,7 @@ export class Timeline {
   }
 
   getDataIndices(n0: number, n1: number): [number, number] {
-    if(n0 > n1) {
+    if (n0 > n1) {
       const tmp = n1;
       n1 = n0;
       n0 = tmp;
@@ -340,14 +340,14 @@ export class Timeline {
     n0 = Math.round(n0);
     n1 = Math.round(n1);
     const brushStart = this.ceil(Math.ceil(n0));
-    const brushEnd =  this.ceil(Math.ceil(n1));
+    const brushEnd = this.ceil(Math.ceil(n1));
 
     return [brushStart, brushEnd];
   }
 
   updateSingleSelection() {
     dataStoreTimelines.get(this.datasetName).clearSingleSelection();
-    if(!this.singleEpochSelector.hidden) {
+    if (!this.singleEpochSelector.hidden) {
       console.assert(this.data.datapoints[this.singleEpochSelector.curPos].exists);
       const epoch = this.data.datapoints[this.singleEpochSelector.curPos].epoch;
       console.assert(!!epoch);

--- a/src/timeline/TimelineCollection.ts
+++ b/src/timeline/TimelineCollection.ts
@@ -91,6 +91,10 @@ export class TimelineCollection {
     });
   }
 
+  getMaxDSWidth(): number {
+    return Math.max(...this.timelines.filter((d) => d !== null).map((d) => d.getWidth()));
+  }
+
   private findMaxDSLabelWidth() {
     return this.timelines.reduce((acc, val) => {
       return val !== null && val.getDSLabelWidth() > acc ? val.getDSLabelWidth() : acc;

--- a/src/timeline/TimelineView.ts
+++ b/src/timeline/TimelineView.ts
@@ -11,7 +11,7 @@ import {Timeline} from './Timeline';
 import {dataStoreTimelines, DataStoreTimelineSelection} from '../DataStore';
 
 export default class TimelineView implements IAppView {
-  private readonly $node:d3.Selection<any>;
+  private readonly $node: d3.Selection<any>;
   private timelineData: TimelineCollection;
   private width: number;
 
@@ -28,18 +28,18 @@ export default class TimelineView implements IAppView {
   }
 
   updateSvg(timeLineCount: number) {
-      this.$node.attr('viewBox', `0 0 ${this.width} ${(timeLineCount) * AppConstants.TML_HEIGHT}`);
-      this.$node.attr('height', '100%');
-      this.$node.classed('hidden', timeLineCount === 0);
+    this.$node.attr('viewBox', `0 0 ${this.width} ${(timeLineCount) * AppConstants.TML_HEIGHT}`);
+    this.$node.attr('height', '100%');
+    this.$node.classed('hidden', timeLineCount === 0);
   }
 
   private attachListener() {
-    events.on(AppConstants.EVENT_DATA_SET_ADDED, (evt, ds:MalevoDataset) => {
+    events.on(AppConstants.EVENT_DATA_SET_ADDED, (evt, ds: MalevoDataset) => {
       this.updateSvg(this.timelineData.timelineCount() + 1);
       this.timelineData.add(this.$node, ds);
     });
 
-    events.on(AppConstants.EVENT_DATA_SET_REMOVED, (evt, ds:MalevoDataset) => {
+    events.on(AppConstants.EVENT_DATA_SET_REMOVED, (evt, ds: MalevoDataset) => {
       this.updateSvg(this.timelineData.timelineCount() - 1);
       this.timelineData.remove(ds);
     });
@@ -63,6 +63,6 @@ export default class TimelineView implements IAppView {
  * @param options
  * @returns {HeatMap}
  */
-export function create(parent:Element, options:any) {
+export function create(parent: Element, options: any) {
   return new TimelineView(parent);
 }

--- a/src/timeline/TimelineView.ts
+++ b/src/timeline/TimelineView.ts
@@ -27,21 +27,21 @@ export default class TimelineView implements IAppView {
     this.timelineData = new TimelineCollection(this.$node);
   }
 
-  updateSvg(timeLineCount: number) {
-    this.$node.attr('viewBox', `0 0 ${this.width} ${(timeLineCount) * AppConstants.TML_HEIGHT}`);
+  updateSvg(timeLineCount: number, maxWidth: number) {
+    this.$node.attr('viewBox', `0 0 ${Math.max(this.width, maxWidth)} ${(timeLineCount) * AppConstants.TML_HEIGHT}`);
     this.$node.attr('height', '100%');
     this.$node.classed('hidden', timeLineCount === 0);
   }
 
   private attachListener() {
     events.on(AppConstants.EVENT_DATA_SET_ADDED, (evt, ds: MalevoDataset) => {
-      this.updateSvg(this.timelineData.timelineCount() + 1);
       this.timelineData.add(this.$node, ds);
+      this.updateSvg(this.timelineData.timelineCount(), this.timelineData.getMaxDSWidth());
     });
 
     events.on(AppConstants.EVENT_DATA_SET_REMOVED, (evt, ds: MalevoDataset) => {
-      this.updateSvg(this.timelineData.timelineCount() - 1);
       this.timelineData.remove(ds);
+      this.updateSvg(this.timelineData.timelineCount(), this.timelineData.getMaxDSWidth());
     });
   }
 


### PR DESCRIPTION
Closes #129.

Note: The timeline is scaled to match the container width. The new timeline layout will be available with #126.

Other changes:
* Rotate (left) matrix labels
* Make ground truth/predicted label less salient save some space
* New tab style
* Gap between matrix and objectives

![image](https://user-images.githubusercontent.com/5851088/39636438-756ad30c-4fc0-11e8-8f59-465179f5735a.png)

