### PR TITLE
Make matrix layout flexible using CSS custom properties

### DIFF
--- a/src/ConfusionMatrix.ts
+++ b/src/ConfusionMatrix.ts
@@ -84,7 +84,7 @@ export class ConfusionMatrix implements IAppView {
     $labelRight.append('div')
       .text(Language.CLASS_SIZE);
 
-    this.$node.append('div')
+    const $labelBottom = this.$node.append('div')
       .classed('malevo-label', true)
       .classed('label-bottom', true)
       .html(`<span>${Language.FP}</span>`);
@@ -114,6 +114,12 @@ export class ConfusionMatrix implements IAppView {
 
     const $chartBottom = this.$node.append('div').classed('chart-bottom', true);
     this.fpColumn = new ChartColumn($chartBottom.append('div'));
+
+    const numRightColumns = 3; // number of additional columns
+    this.$node.style('--num-right-columns', numRightColumns);
+
+    const numBottomColumns = 1; // number of additional columns
+    this.$node.style('--num-bottom-columns', numBottomColumns);
   }
 
   private attachListeners() {
@@ -361,8 +367,10 @@ export class ConfusionMatrix implements IAppView {
       dataPrecision = datasets.map((x) => confMeasures.calcEvolution([x.singleEpochData.confusionData], confMeasures.PPV));
       singleEpochIndex = data[0].heatcell.indexInMultiSelection;
 
-      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapSingleEpochRenderer', params: [false, false]}],
-        diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener, this.setYAxisScaleListener]};
+      confMatrixRendererProto = {
+        offdiagonal: [{renderer: 'HeatmapSingleEpochRenderer', params: [false, false]}],
+        diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener, this.setYAxisScaleListener]
+      };
       fpfnRendererProto = {
         diagonal: [{renderer: 'BarChartRenderer', params: null}], offdiagonal: null,
         functors: [this.setWeightUpdateListener, this.setYAxisScaleListener]
@@ -379,8 +387,10 @@ export class ConfusionMatrix implements IAppView {
       dataPrecision = datasets.map((x) => confMeasures.calcEvolution(x.multiEpochData.map((y) => y.confusionData), confMeasures.PPV));
       singleEpochIndex = null;
 
-      confMatrixRendererProto = {offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params: [DataStoreApplicationProperties.transposeCellRenderer]}],
-        diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener, this.setYAxisScaleListener]};
+      confMatrixRendererProto = {
+        offdiagonal: [{renderer: 'HeatmapMultiEpochRenderer', params: [DataStoreApplicationProperties.transposeCellRenderer]}],
+        diagonal: [{renderer: 'LabelCellRenderer', params: null}], functors: [this.setWeightUpdateListener, this.setYAxisScaleListener]
+      };
       fpfnRendererProto = {
         diagonal: [{renderer: 'MatrixLineCellRenderer', params: null}], offdiagonal: null,
         functors: [this.setWeightUpdateListener, this.setYAxisScaleListener]

--- a/src/styles/_confusionmatrix.scss
+++ b/src/styles/_confusionmatrix.scss
@@ -2,9 +2,6 @@
 @import '~font-awesome/scss/variables';
 @import '~font-awesome/scss/mixins';
 
-// number of columns placed to the right of the confusion matrix
-$num-columns-right-area: 3;
-
 @mixin rotateSpanLabel() {
   > span {
     display: block;
@@ -51,7 +48,7 @@ $num-columns-right-area: 3;
 .label-right {
   grid-area: label-right;
   background: $label-bg;
-  grid-template-columns: repeat(auto-fill, minmax(100% / $num-columns-right-area, 1fr));
+  grid-template-columns: repeat(var(--num-right-columns), 1fr);
   display: grid;
 
   div {
@@ -94,14 +91,14 @@ $num-columns-right-area: 3;
   grid-area: chart-right;
   position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(100% / $num-columns-right-area, 1fr)); // 100% for one column, 50% for 2 columns, 33% for 3 columns ...
+  grid-template-columns: repeat(var(--num-right-columns), 1fr);
 }
 
 .chart-bottom {
   grid-area: chart-bottom;
   position: relative;
   display: grid;
-  grid-template-rows: repeat(auto-fill, minmax(100%, 1fr)); // 100% for one row, 50% for 2 rows, ...
+  grid-template-rows: repeat(var(--num-bottom-columns), 1fr);
 }
 
 .matrix-wrapper {


### PR DESCRIPTION
Closes Caleydo/malevo#119.

The UI looks the same, but it's more flexible from the code base.