### PR TITLE
Lower bound of 1px for single epoch marker + tick marks dynamically generated

### DIFF
--- a/src/confusion_matrix_cell/ACellRenderer.ts
+++ b/src/confusion_matrix_cell/ACellRenderer.ts
@@ -234,8 +234,16 @@ export class SingleEpochMarker extends ACellRenderer implements ITransposeRender
 
     const firstHCPart = d3.select(cell.$node.selectAll('div.heat-cell')[0][0]); // select first part of heat cell
     let bg = firstHCPart.style('background');
-    const position = (this.isTransposed) ? `0px ${res * singleEpochIndex}px` : `${res * singleEpochIndex}px 0px`;
-    res = res < 1 ? 1 : res;
+    let position = null;
+    const markerMinSize = 1;
+    // when marker is smaller 1 and last epoch is selected, shift marker to the left
+    if (res < markerMinSize && largest - markerMinSize === singleEpochIndex) {
+      position = res * largest - markerMinSize;
+    } else {
+      position = res * singleEpochIndex;
+    }
+    position = (this.isTransposed) ? `0px ${position}px` : `${position}px 0px`;
+    res = res < markerMinSize ? markerMinSize : res;
     const size = (this.isTransposed) ? `2px ${res}px ` : `${res}px 2px`;
     const str = `linear-gradient(to right, rgb(0, 0, 0), rgb(0, 0, 0)) ${position} / ${size} no-repeat,`;
     bg = str + bg;

--- a/src/confusion_matrix_cell/ACellRenderer.ts
+++ b/src/confusion_matrix_cell/ACellRenderer.ts
@@ -454,11 +454,9 @@ export class AxisRenderer extends ACellRenderer {
       .domain([0, getYMax(cell, this.data)]);
 
     //todo these are magic constants: use a more sophisticated algo to solve this
-    let tickFrequency = 1;
-    const stride = Number(values[1]) - Number(values[0]);
-    if (stride <= 5) {
-      tickFrequency = 4;
-    }
+    const labelWidth = 25; // in pixel
+    const numTicks = this.width / labelWidth;
+    const tickFrequency = Math.ceil(values.length / numTicks);
 
     const ticks = values.filter((x, i) => i % tickFrequency === 0);
     const xAxis = d3.svg.axis()

--- a/src/confusion_matrix_cell/ACellRenderer.ts
+++ b/src/confusion_matrix_cell/ACellRenderer.ts
@@ -230,11 +230,12 @@ export class SingleEpochMarker extends ACellRenderer implements ITransposeRender
 
     const data: Line[] = [].concat.apply([], cell.data.linecell);
     const largest = getLargestLine(data).values.length;
-    const res = width / largest;
+    let res = width / largest;
 
     const firstHCPart = d3.select(cell.$node.selectAll('div.heat-cell')[0][0]); // select first part of heat cell
     let bg = firstHCPart.style('background');
     const position = (this.isTransposed) ? `0px ${res * singleEpochIndex}px` : `${res * singleEpochIndex}px 0px`;
+    res = res < 1 ? 1 : res;
     const size = (this.isTransposed) ? `2px ${res}px ` : `${res}px 2px`;
     const str = `linear-gradient(to right, rgb(0, 0, 0), rgb(0, 0, 0)) ${position} / ${size} no-repeat,`;
     bg = str + bg;
@@ -250,9 +251,11 @@ export class SingleEpochMarker extends ACellRenderer implements ITransposeRender
   }
 
   public addYAxisScaleChangedListener() {
+    events.on(AppConstants.EVENT_SWITCH_SCALE_TO_ABSOLUTE, this.update);
   }
 
   public removeYAxisScaleChangedListener() {
+    events.off(AppConstants.EVENT_SWITCH_SCALE_TO_ABSOLUTE, this.update);
   }
 }
 


### PR DESCRIPTION
Closes #164 #203

Lower bound of 1xp for single epoch marker
tick marks dynamically generated


![image](https://user-images.githubusercontent.com/3988444/42683631-2e7ac8c6-868e-11e8-8c0d-02709e1f1ffb.png)
